### PR TITLE
Switch diarization pipeline to v3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install -r requirements.txt
 
 2. Get a HuggingFace token with access to pyannote.audio models:
    - Create an account on [HuggingFace](https://huggingface.co/)
-   - Visit [pyannote/speaker-diarization-3.0](https://huggingface.co/pyannote/speaker-diarization-3.0)
+   - Visit [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1)
    - Accept the license agreement
    - Create an access token in your [HuggingFace settings](https://huggingface.co/settings/tokens)
 

--- a/python/README.md
+++ b/python/README.md
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 
 3. Get a HuggingFace token with access to the pyannote.audio models:
    - Create an account on [HuggingFace](https://huggingface.co/)
-   - Visit the [pyannote/speaker-diarization-3.0](https://huggingface.co/pyannote/speaker-diarization-3.0) model page
+   - Visit the [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) model page
    - Accept the license agreement
    - Create an access token in your [HuggingFace settings](https://huggingface.co/settings/tokens)
 

--- a/python/diarization.py
+++ b/python/diarization.py
@@ -33,8 +33,10 @@ def diarize_audio(audio_path, num_speakers=None, hf_token=None):
     
     # Initialize the diarization pipeline
     try:
+        # Use the latest diarization pipeline. Version 3.1 relies on the
+        # segmentation model 3.0 under the hood.
         pipeline = Pipeline.from_pretrained(
-            "pyannote/speaker-diarization-3.0",
+            "pyannote/speaker-diarization-3.1",
             use_auth_token=hf_token
         ).to(device)
     except Exception as e:

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -81,7 +81,7 @@ async function checkDiarizationAvailability() {
       console.log('For multi-speaker transcription with Pyannote, please install pyannote.audio:');
       console.log('1. cd python');
       console.log('2. pip install -r requirements.txt');
-      console.log('3. Get a HuggingFace token with access to pyannote/speaker-diarization-3.0');
+      console.log('3. Get a HuggingFace token with access to pyannote/speaker-diarization-3.1');
       console.log('4. Set HUGGINGFACE_TOKEN environment variable');
     }
     


### PR DESCRIPTION
## Summary
- use `pyannote/speaker-diarization-3.1` in the Python diarization script
- update docs to reference the v3.1 model
- tweak server setup instructions

## Testing
- `pip install -r python/requirements.txt` *(fails: Could not connect to proxy)*
- `npm run check` *(fails: Cannot find type definition file for 'node')*