### PR TITLE
Add semantic search scaffold

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import express, { type Request, Response, NextFunction } from "express";
+import rateLimit from 'express-rate-limit';
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import dotenv from 'dotenv';
@@ -11,6 +12,12 @@ const app = express();
 // Increase body size limits to handle large file uploads
 app.use(express.json({ limit: '500mb' }));
 app.use(express.urlencoded({ extended: false, limit: '500mb' }));
+
+const searchLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+});
+app.use('/api/search', searchLimiter);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/openai.ts
+++ b/server/openai.ts
@@ -38,6 +38,16 @@ async function withRetry<T>(
   }
 }
 
+export async function embedText(text: string): Promise<number[]> {
+  const resp = await limiter.schedule(() =>
+    withRetry(() =>
+      openai.embeddings.create({ model: "text-embedding-3-small", input: text })
+    )
+  );
+  const embedding = (resp as any).data?.[0]?.embedding || [];
+  return embedding;
+}
+
 export async function transcribeAudio(
   audioFilePath: string
 ): Promise<{ text: string; duration?: number; language?: string }> {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12,14 +12,15 @@ import multer from "multer";
 import path from "path";
 import fs from "fs";
 import os from "os";
-import { 
-  transcribeAudio, 
+import {
+  transcribeAudio,
   transcribeAudioWithFeatures,
   transcribeWithPyannote,
-  generateTranscriptSummary, 
+  generateTranscriptSummary,
   translateTranscript,
   autoMergeSpeakers
 } from "./openai";
+import { indexTranscript, searchTranscript } from "./search";
 import { transcribeWithAssemblyAI, formatTranscriptText } from "./assemblyai";
 import { transcribeWithHybridApproach } from "./hybrid";
 import { generateTranscriptPDF } from "./pdf";
@@ -407,6 +408,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             hasTimestamps: metadata.enableTimestamps,
             structuredTranscript: JSON.stringify(result.structuredTranscript)
           });
+          await indexTranscript(transcriptionId, result.structuredTranscript.segments);
           
         } catch (error) {
           console.error("Error during chunked file transcription:", error);
@@ -635,8 +637,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
             speakerLabels: enableSpeakerLabels && result.structuredTranscript.segments.some(s => s.speaker),
             hasTimestamps: enableTimestamps,
             // Store structured transcript as JSON string
-            structuredTranscript: JSON.stringify(result.structuredTranscript) 
+            structuredTranscript: JSON.stringify(result.structuredTranscript)
           });
+          await indexTranscript(transcription.id, result.structuredTranscript.segments);
         } catch (error) {
           // Handle errors and update the record (Original simpler error handling)
           const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1368,8 +1371,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
                   speakerLabels: enableSpeakerLabels && result.structuredTranscript.segments.some(s => s.speaker),
                   hasTimestamps: enableTimestamps,
                   // Store structured transcript as JSON string
-                  structuredTranscript: JSON.stringify(result.structuredTranscript) 
+                  structuredTranscript: JSON.stringify(result.structuredTranscript)
                 });
+                await indexTranscript(id, result.structuredTranscript.segments);
               } else {
                 // Use basic transcription for simple cases
                 const result = await transcribeAudio(file.path);
@@ -1542,6 +1546,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error merging speakers:", error);
       return res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // Semantic search across a transcription
+  app.get('/api/search', async (req: Request, res: Response) => {
+    try {
+      const query = z.string().min(1).parse(req.query.q);
+      const transcriptId = z.coerce.number().parse(req.query.transcript_id);
+      const top = req.query.top ? z.coerce.number().parse(req.query.top) : 10;
+
+      const results = await searchTranscript(transcriptId, query, top);
+      return res.json(results);
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const message = fromZodError(err).message;
+        return res.status(400).json({ message });
+      }
+      console.error('search error', err);
+      return res.status(500).json({ message: 'search failed' });
     }
   });
 

--- a/server/search.ts
+++ b/server/search.ts
@@ -1,0 +1,50 @@
+import { db } from './db';
+import { transcriptVectors } from '@shared/schema';
+import { sql } from 'drizzle-orm';
+import { embedText } from './openai';
+import { TranscriptSegment } from '@shared/schema';
+
+export async function indexTranscript(
+  transcriptId: number,
+  segments: TranscriptSegment[]
+): Promise<void> {
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const embedding = await embedText(seg.text);
+    await db.insert(transcriptVectors).values({
+      transcriptId,
+      chunkId: i,
+      speaker: seg.speaker ?? null,
+      text: seg.text,
+      tsStart: seg.start,
+      tsEnd: seg.end,
+      tokenStart: 0,
+      tokenEnd: seg.text.split(/\s+/).length,
+      embedding,
+    });
+  }
+}
+
+export async function searchTranscript(
+  transcriptId: number,
+  query: string,
+  top: number
+): Promise<{
+  chunk_id: number;
+  speaker: string | null;
+  ts_start: number | null;
+  ts_end: number | null;
+  text: string | null;
+  score: number;
+}[]> {
+  const embedding = await embedText(query);
+  const result = await db.execute(sql`
+    SELECT chunk_id, speaker, ts_start, ts_end, text,
+      1 - (embedding <#> ${embedding}) AS score
+    FROM transcript_vectors
+    WHERE transcript_id = ${transcriptId}
+    ORDER BY embedding <#> ${embedding}
+    LIMIT ${top}
+  `);
+  return result.rows as any;
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,5 @@
-import { pgTable, text, serial, integer, boolean, timestamp, real } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, boolean, timestamp, real, numeric, varchar } from "drizzle-orm/pg-core";
+import { vector } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -100,3 +101,20 @@ export const structuredTranscriptSchema = z.object({
 });
 
 export type StructuredTranscript = z.infer<typeof structuredTranscriptSchema>;
+
+export const transcriptVectors = pgTable("transcript_vectors", {
+  id: serial("id").primaryKey(),
+  transcriptId: integer("transcript_id").notNull().references(() => transcriptions.id),
+  chunkId: integer("chunk_id").notNull(),
+  speaker: varchar("speaker", { length: 64 }),
+  text: text("text"),
+  tsStart: numeric("ts_start", { precision: 8, scale: 2 }),
+  tsEnd: numeric("ts_end", { precision: 8, scale: 2 }),
+  tokenStart: integer("token_start"),
+  tokenEnd: integer("token_end"),
+  embedding: vector("embedding", { dimensions: 1536 }),
+});
+
+export const insertVectorSchema = createInsertSchema(transcriptVectors);
+export type InsertVector = z.infer<typeof insertVectorSchema>;
+export type TranscriptVector = typeof transcriptVectors.$inferSelect;


### PR DESCRIPTION
## Summary
- add `transcript_vectors` table to schema
- implement OpenAI embedding helper
- create indexing and search utilities
- call indexer when transcription completes
- expose `/api/search` route
- add rate limiting for search

## Testing
- `npm run check` *(fails: cannot find modules and type errors)*