### PR TITLE
Add action-item comment webhook

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1053,6 +1053,52 @@ export async function registerRoutes(app: Express): Promise<Server> {
       return res.status(500).json({ message: "Error translating transcription" });
     }
   });
+
+  // Create a comment for a transcription
+  app.post('/api/transcriptions/:id/comments', async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id);
+      if (isNaN(id)) {
+        return res.status(400).json({ message: 'Invalid transcription ID' });
+      }
+
+      const { text, kind } = req.body;
+      if (!text || typeof text !== 'string') {
+        return res.status(400).json({ message: 'Comment text is required' });
+      }
+      if (!kind || typeof kind !== 'string') {
+        return res.status(400).json({ message: 'Comment kind is required' });
+      }
+
+      const transcription = await storage.getTranscription(id);
+      if (!transcription) {
+        return res.status(404).json({ message: 'Transcription not found' });
+      }
+
+      const comment = await storage.createComment({
+        transcriptionId: id,
+        text,
+        kind,
+      });
+
+      if (kind === 'action-item' && process.env.ACTION_ITEM_WEBHOOK_URL) {
+        try {
+          await fetch(process.env.ACTION_ITEM_WEBHOOK_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ transcriptionId: id, text }),
+          });
+        } catch (err) {
+          console.error('Failed to forward action item:', err);
+        }
+      }
+
+      return res.status(201).json(comment);
+    } catch (error) {
+      console.error('Error creating comment:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  });
   
   // Download a transcription as PDF
   app.get('/api/transcriptions/:id/pdf', async (req: Request, res: Response) => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,11 @@
-import { transcriptions, type Transcription, type InsertTranscription } from "@shared/schema";
+import {
+  transcriptions,
+  comments,
+  type Transcription,
+  type InsertTranscription,
+  type Comment,
+  type InsertComment,
+} from "@shared/schema";
 import { db } from "./db";
 import { eq } from "drizzle-orm";
 import fs from 'fs';
@@ -12,6 +19,8 @@ export interface IStorage {
   deleteTranscription(id: number): Promise<void>;
   storeAudioFile(id: number, audioBuffer: Buffer, fileType: string): Promise<string>;
   getAudioFilePath(id: number): Promise<string | null>;
+  createComment(comment: InsertComment): Promise<Comment>;
+  listComments(transcriptionId: number): Promise<Comment[]>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -98,16 +107,32 @@ export class DatabaseStorage implements IStorage {
     
     return path.join(audioDir, audioFile);
   }
+
+  async createComment(comment: InsertComment): Promise<Comment> {
+    const [created] = await db.insert(comments).values(comment).returning();
+    return created;
+  }
+
+  async listComments(transcriptionId: number): Promise<Comment[]> {
+    return await db
+      .select()
+      .from(comments)
+      .where(eq(comments.transcriptionId, transcriptionId));
+  }
 }
 
 // For backwards compatibility, we can keep this class
 export class MemStorage implements IStorage {
   private transcriptions: Map<number, Transcription>;
+  private comments: Map<number, Comment[]>;
   currentId: number;
+  private commentId: number;
 
   constructor() {
     this.transcriptions = new Map();
+    this.comments = new Map();
     this.currentId = 1;
+    this.commentId = 1;
   }
 
   async createTranscription(insertTranscription: InsertTranscription): Promise<Transcription> {
@@ -221,6 +246,22 @@ export class MemStorage implements IStorage {
     }
     
     return path.join(audioDir, audioFile);
+  }
+
+  async createComment(comment: InsertComment): Promise<Comment> {
+    const newComment: Comment = {
+      id: this.commentId++,
+      createdAt: new Date(),
+      ...comment,
+    } as Comment;
+    const arr = this.comments.get(comment.transcriptionId) || [];
+    arr.push(newComment);
+    this.comments.set(comment.transcriptionId, arr);
+    return newComment;
+  }
+
+  async listComments(transcriptionId: number): Promise<Comment[]> {
+    return this.comments.get(transcriptionId) || [];
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -100,3 +100,22 @@ export const structuredTranscriptSchema = z.object({
 });
 
 export type StructuredTranscript = z.infer<typeof structuredTranscriptSchema>;
+
+export const comments = pgTable("comments", {
+  id: serial("id").primaryKey(),
+  transcriptionId: integer("transcription_id")
+    .references(() => transcriptions.id)
+    .notNull(),
+  text: text("text").notNull(),
+  kind: text("kind").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertCommentSchema = createInsertSchema(comments).pick({
+  transcriptionId: true,
+  text: true,
+  kind: true,
+});
+
+export type InsertComment = z.infer<typeof insertCommentSchema>;
+export type Comment = typeof comments.$inferSelect;


### PR DESCRIPTION
## Summary
- allow storing comments in DB
- store comments via storage layer
- POST comment when kind is `action-item`

## Testing
- `npm run check` *(fails: Cannot find module 'react')*