### PR TITLE
Add transcription collab token endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
+    "jsonwebtoken": "^9.0.2",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,6 +23,7 @@ import {
 import { transcribeWithAssemblyAI, formatTranscriptText } from "./assemblyai";
 import { transcribeWithHybridApproach } from "./hybrid";
 import { generateTranscriptPDF } from "./pdf";
+import jwt from "jsonwebtoken";
 import { z } from "zod";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
@@ -1205,6 +1206,41 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error serving audio file:", error);
       return res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // Generate a collaboration token for a transcription
+  app.get('/api/transcriptions/:id/collab-token', async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id);
+      if (isNaN(id)) {
+        return res.status(400).json({ message: 'Invalid transcription ID' });
+      }
+
+      const transcription = await storage.getTranscription(id);
+      if (!transcription) {
+        return res.status(404).json({ message: 'Transcription not found' });
+      }
+
+      const scopesParam = req.query.scopes;
+      let scopes: string[] = [];
+      if (typeof scopesParam === 'string') {
+        scopes = scopesParam.split(',').map(s => s.trim()).filter(s => s === 'read' || s === 'write');
+      }
+      if (scopes.length === 0) {
+        scopes = ['read'];
+      }
+
+      const secret = process.env.COLLAB_TOKEN_SECRET;
+      if (!secret) {
+        return res.status(500).json({ message: 'Collaboration token secret is not configured' });
+      }
+
+      const token = jwt.sign({ transcriptionId: id, scopes }, secret, { expiresIn: '2h' });
+      return res.status(200).json({ token });
+    } catch (error) {
+      console.error('Error generating collaboration token:', error);
+      return res.status(500).json({ message: 'Internal server error' });
     }
   });
 


### PR DESCRIPTION
## Summary
- add jsonwebtoken dependency
- allow generating collaboration tokens via `GET /api/transcriptions/:id/collab-token`

## Testing
- `npm run check` *(fails: Cannot find module errors)*