### PR TITLE
Add revision and comment tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ export DATABASE_URL="sqlite://local.db"
 
 # Start the application
 npm run dev
+
+# Generate database migrations
+npx drizzle-kit push
 ```
 
 ### Advanced Speaker Recognition Setup

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp, real } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, boolean, timestamp, real, bytea, jsonb } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -100,3 +100,35 @@ export const structuredTranscriptSchema = z.object({
 });
 
 export type StructuredTranscript = z.infer<typeof structuredTranscriptSchema>;
+
+export const transcriptRevisions = pgTable("transcript_revisions", {
+  id: serial("id").primaryKey(),
+  transcriptId: integer("transcript_id")
+    .references(() => transcriptions.id)
+    .notNull(),
+  revNo: integer("rev_no").notNull(),
+  doc: bytea("doc").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertTranscriptRevisionSchema = createInsertSchema(transcriptRevisions);
+export type InsertTranscriptRevision = z.infer<typeof insertTranscriptRevisionSchema>;
+export type TranscriptRevision = typeof transcriptRevisions.$inferSelect;
+
+export const comments = pgTable("comments", {
+  id: serial("id").primaryKey(),
+  transcriptId: integer("transcript_id")
+    .references(() => transcriptions.id)
+    .notNull(),
+  yjsPos: jsonb("yjs_pos").notNull(),
+  body: text("body").notNull(),
+  kind: text("kind").notNull(),
+  status: text("status").notNull(),
+  assignee: text("assignee"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+export const insertCommentSchema = createInsertSchema(comments);
+export type InsertComment = z.infer<typeof insertCommentSchema>;
+export type Comment = typeof comments.$inferSelect;


### PR DESCRIPTION
## Summary
- add transcript revisions and comments tables to the shared schema
- export their insert schemas and types
- document running `npx drizzle-kit push` in the README

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run db:push` *(fails: `dotenv` not found)*