### PR TITLE
Add revision history endpoints

### DIFF
--- a/client/src/pages/TranscriptionDetail.tsx
+++ b/client/src/pages/TranscriptionDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useRoute, useLocation } from 'wouter';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiRequest, getQueryFn } from "@/lib/queryClient";
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2, Trash, Download, FileText } from 'lucide-react';
 import { Transcription, StructuredTranscript } from '@shared/schema';
+import DiffMatchPatch from 'diff-match-patch';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -34,6 +35,7 @@ export default function TranscriptionDetail() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isGeneratingSummary, setIsGeneratingSummary] = useState(false);
   const [isMergingSpeakers, setIsMergingSpeakers] = useState(false);
+  const [selectedRev, setSelectedRev] = useState<number | null>(null);
   
   const id = params?.id;
 
@@ -43,6 +45,34 @@ export default function TranscriptionDetail() {
     queryFn: getQueryFn({ on401: "throw" }),
     enabled: !!id,
   });
+
+  const { data: revisions = [] } = useQuery({
+    queryKey: [`/api/transcriptions/${id}/revisions`],
+    queryFn: getQueryFn({ on401: 'throw' }),
+    enabled: !!id,
+  });
+
+  const { data: revisionText } = useQuery({
+    queryKey: [`/api/transcriptions/${id}/revisions`, selectedRev],
+    queryFn: async () => {
+      const response = await apiRequest(
+        'GET',
+        `/api/transcriptions/${id}/revisions/${selectedRev}`
+      );
+      return await response.text();
+    },
+    enabled: !!id && selectedRev !== null,
+  });
+
+  const diffHtml = useMemo(() => {
+    if (revisionText && transcription?.text) {
+      const dmp = new DiffMatchPatch();
+      const diff = dmp.diff_main(revisionText, transcription.text);
+      dmp.diff_cleanupSemantic(diff);
+      return dmp.diff_prettyHtml(diff);
+    }
+    return '';
+  }, [revisionText, transcription?.text]);
 
   // Handle save transcript mutation
   const saveTranscriptMutation = useMutation({
@@ -330,10 +360,11 @@ export default function TranscriptionDetail() {
         )}
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-3 bg-white shadow-sm mb-2">
+          <TabsList className="grid w-full max-w-md grid-cols-4 bg-white shadow-sm mb-2">
             <TabsTrigger value="view" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">View</TabsTrigger>
             <TabsTrigger value="edit" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">Edit</TabsTrigger>
             <TabsTrigger value="speakers" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">Speakers</TabsTrigger>
+            <TabsTrigger value="history" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">History</TabsTrigger>
           </TabsList>
 
           <TabsContent value="view" className="mt-4">
@@ -365,10 +396,27 @@ export default function TranscriptionDetail() {
 
           <TabsContent value="speakers" className="mt-4">
             {transcription.structuredTranscript && (
-              <SpeakerSimilarity 
+              <SpeakerSimilarity
                 transcriptionId={parseInt(id)}
                 onMergeSpeakers={(targetCount) => mergeSpeakersMutation.mutateAsync(targetCount)}
               />
+            )}
+          </TabsContent>
+
+          <TabsContent value="history" className="mt-4 space-y-4">
+            <div className="flex flex-wrap gap-2">
+              {revisions.map((rev: any) => (
+                <Button
+                  key={rev.revisionNo}
+                  variant={rev.revisionNo === selectedRev ? 'default' : 'outline'}
+                  onClick={() => setSelectedRev(rev.revisionNo)}
+                >
+                  {rev.revisionNo}
+                </Button>
+              ))}
+            </div>
+            {diffHtml && (
+              <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: diffHtml }} />
             )}
           </TabsContent>
         </Tabs>

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
+    "diff-match-patch": "^1.0.5",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -704,7 +704,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!transcription) {
         return res.status(404).json({ message: "Transcription not found" });
       }
-      
+
       // Parse structured transcript from JSON string if it exists
       let structuredTranscript = null;
       if (transcription.structuredTranscript) {
@@ -842,7 +842,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!transcription) {
         return res.status(404).json({ message: "Transcription not found" });
       }
-      
+
+      if (transcription.text) {
+        await storage.addRevision(id, transcription.text);
+      }
+
       const updatedTranscription = await storage.updateTranscription(id, {
         text,
         updatedAt: new Date(),
@@ -1205,6 +1209,44 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error serving audio file:", error);
       return res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // Get transcription revisions metadata
+  app.get('/api/transcriptions/:id/revisions', async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id);
+      if (isNaN(id)) {
+        return res.status(400).json({ message: 'Invalid transcription ID' });
+      }
+
+      const revisions = await storage.listRevisions(id);
+      return res.json(revisions);
+    } catch (error) {
+      console.error('Error retrieving revisions:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  });
+
+  // Get specific revision text
+  app.get('/api/transcriptions/:id/revisions/:rev_no', async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id);
+      const revNo = parseInt(req.params.rev_no);
+      if (isNaN(id) || isNaN(revNo)) {
+        return res.status(400).json({ message: 'Invalid transcription or revision ID' });
+      }
+
+      const revision = await storage.getRevision(id, revNo);
+      if (!revision) {
+        return res.status(404).json({ message: 'Revision not found' });
+      }
+
+      res.setHeader('Content-Type', 'text/plain');
+      return res.status(200).send(revision.text);
+    } catch (error) {
+      console.error('Error retrieving revision:', error);
+      return res.status(500).json({ message: 'Internal server error' });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,6 +1,6 @@
-import { transcriptions, type Transcription, type InsertTranscription } from "@shared/schema";
+import { transcriptions, transcriptionRevisions, type Transcription, type InsertTranscription, type TranscriptionRevision } from "@shared/schema";
 import { db } from "./db";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import fs from 'fs';
 import path from 'path';
 
@@ -12,6 +12,9 @@ export interface IStorage {
   deleteTranscription(id: number): Promise<void>;
   storeAudioFile(id: number, audioBuffer: Buffer, fileType: string): Promise<string>;
   getAudioFilePath(id: number): Promise<string | null>;
+  addRevision(transcriptionId: number, text: string): Promise<void>;
+  listRevisions(transcriptionId: number): Promise<Pick<TranscriptionRevision, 'revisionNo' | 'createdAt'>[]>;
+  getRevision(transcriptionId: number, revisionNo: number): Promise<TranscriptionRevision | undefined>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -98,15 +101,50 @@ export class DatabaseStorage implements IStorage {
     
     return path.join(audioDir, audioFile);
   }
+
+  async addRevision(transcriptionId: number, text: string): Promise<void> {
+    const revisions = await db
+      .select({ revisionNo: transcriptionRevisions.revisionNo })
+      .from(transcriptionRevisions)
+      .where(eq(transcriptionRevisions.transcriptionId, transcriptionId));
+
+    const nextNo = (revisions.sort((a, b) => b.revisionNo - a.revisionNo)[0]?.revisionNo || 0) + 1;
+
+    await db.insert(transcriptionRevisions).values({
+      transcriptionId,
+      revisionNo: nextNo,
+      text,
+    });
+  }
+
+  async listRevisions(transcriptionId: number): Promise<Pick<TranscriptionRevision, 'revisionNo' | 'createdAt'>[]> {
+    return db
+      .select({ revisionNo: transcriptionRevisions.revisionNo, createdAt: transcriptionRevisions.createdAt })
+      .from(transcriptionRevisions)
+      .where(eq(transcriptionRevisions.transcriptionId, transcriptionId));
+  }
+
+  async getRevision(transcriptionId: number, revisionNo: number): Promise<TranscriptionRevision | undefined> {
+    const [rev] = await db
+      .select()
+      .from(transcriptionRevisions)
+      .where(and(
+        eq(transcriptionRevisions.transcriptionId, transcriptionId),
+        eq(transcriptionRevisions.revisionNo, revisionNo)
+      ));
+    return rev || undefined;
+  }
 }
 
 // For backwards compatibility, we can keep this class
 export class MemStorage implements IStorage {
   private transcriptions: Map<number, Transcription>;
+  private revisions: Map<number, TranscriptionRevision[]>;
   currentId: number;
 
   constructor() {
     this.transcriptions = new Map();
+    this.revisions = new Map();
     this.currentId = 1;
   }
 
@@ -221,6 +259,28 @@ export class MemStorage implements IStorage {
     }
     
     return path.join(audioDir, audioFile);
+  }
+
+  async addRevision(transcriptionId: number, text: string): Promise<void> {
+    const list = this.revisions.get(transcriptionId) || [];
+    const nextNo = (list[list.length - 1]?.revisionNo || 0) + 1;
+    list.push({
+      id: nextNo, // id is not used, but keep field
+      transcriptionId,
+      revisionNo: nextNo,
+      text,
+      createdAt: new Date(),
+    } as TranscriptionRevision);
+    this.revisions.set(transcriptionId, list);
+  }
+
+  async listRevisions(transcriptionId: number): Promise<Pick<TranscriptionRevision, 'revisionNo' | 'createdAt'>[]> {
+    return (this.revisions.get(transcriptionId) || []).map(r => ({ revisionNo: r.revisionNo, createdAt: r.createdAt }));
+  }
+
+  async getRevision(transcriptionId: number, revisionNo: number): Promise<TranscriptionRevision | undefined> {
+    const list = this.revisions.get(transcriptionId) || [];
+    return list.find(r => r.revisionNo === revisionNo);
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -58,6 +58,19 @@ export const insertTranscriptionSchemaTyped = insertTranscriptionSchema.extend({
 export type InsertTranscription = z.infer<typeof insertTranscriptionSchemaTyped>;
 export type Transcription = typeof transcriptions.$inferSelect;
 
+// Table to store transcription revisions
+export const transcriptionRevisions = pgTable("transcription_revisions", {
+  id: serial("id").primaryKey(),
+  transcriptionId: integer("transcription_id")
+    .references(() => transcriptions.id)
+    .notNull(),
+  revisionNo: integer("revision_no").notNull(),
+  text: text("text").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export type TranscriptionRevision = typeof transcriptionRevisions.$inferSelect;
+
 // Schema for file upload
 export const audioFileSchema = z.object({
   file: z.any()


### PR DESCRIPTION
## Summary
- store transcription revisions in database
- expose revision metadata and snapshot endpoints
- keep revision history when updating transcripts
- add diff-based History tab in TranscriptionDetail
- include diff-match-patch dependency

## Testing
- `npm run check` *(fails: numerous missing type declarations)*