### PR TITLE
Implement snapshot persistence and transcript chunking

### DIFF
--- a/client/src/pages/TranscriptionDetail.tsx
+++ b/client/src/pages/TranscriptionDetail.tsx
@@ -77,6 +77,16 @@ export default function TranscriptionDetail() {
     return '';
   }, [revisionText, transcription?.text]);
 
+  const { data: collabToken } = useQuery({
+    queryKey: [`/api/transcriptions/${id}/collab-token`],
+    queryFn: async () => {
+      const res = await apiRequest('GET', `/api/transcriptions/${id}/collab-token?scopes=read,write`);
+      const json = await res.json();
+      return json.token as string;
+    },
+    enabled: !!id && activeTab === 'edit',
+  });
+
   // Handle save transcript mutation
   const saveTranscriptMutation = useMutation({
     mutationFn: async (text: string) => {
@@ -396,11 +406,16 @@ export default function TranscriptionDetail() {
           </TabsContent>
 
           <TabsContent value="edit" className="mt-4">
-            <CollaborativeEditor
-              docId={`transcription-${transcription.id}`}
-              token={"demo-token"}
-              wsUrl="wss://collab.example.com"
-            />
+            {collabToken && (
+              <CollaborativeEditor
+                docId={`transcription-${transcription.id}`}
+                token={collabToken}
+                wsUrl={
+                  (import.meta.env.VITE_COLLAB_URL as string) ||
+                  `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/collab`
+                }
+              />
+            )}
           </TabsContent>
 
           <TabsContent value="speakers" className="mt-4">

--- a/server/chunking.ts
+++ b/server/chunking.ts
@@ -1,0 +1,71 @@
+import { TranscriptSegment } from '@/shared/schema';
+
+export interface TranscriptChunk {
+  text: string;
+  speaker: string | null;
+  tsStart: number;
+  tsEnd: number;
+  tokenStart: number;
+  tokenEnd: number;
+}
+
+export function chunkTranscript(
+  segments: TranscriptSegment[],
+  tokensPerChunk = 200,
+  overlap = 40
+): TranscriptChunk[] {
+  const chunks: TranscriptChunk[] = [];
+  let current: TranscriptChunk | null = null;
+  let globalToken = 0;
+
+  const finalize = () => {
+    if (current) {
+      current.tokenEnd = globalToken;
+      chunks.push(current);
+      current = null;
+    }
+  };
+
+  for (const seg of segments) {
+    const words = seg.text.split(/\s+/);
+    let idx = 0;
+    while (idx < words.length) {
+      if (!current) {
+        current = {
+          text: '',
+          speaker: seg.speaker ?? null,
+          tsStart: seg.start,
+          tsEnd: seg.end,
+          tokenStart: globalToken,
+          tokenEnd: 0,
+        };
+      }
+      const remaining = words.length - idx;
+      const capacity = tokensPerChunk - current.text.split(/\s+/).filter(Boolean).length;
+      const take = Math.min(remaining, capacity);
+      const slice = words.slice(idx, idx + take).join(' ');
+      current.text += (current.text ? ' ' : '') + slice;
+      idx += take;
+      globalToken += take;
+      current.tsEnd = seg.end;
+
+      if (current.text.split(/\s+/).length >= tokensPerChunk) {
+        finalize();
+        if (overlap > 0) {
+          const overlapWords = words.slice(idx - overlap, idx).join(' ');
+          current = {
+            text: overlapWords,
+            speaker: seg.speaker ?? null,
+            tsStart: seg.start,
+            tsEnd: seg.end,
+            tokenStart: globalToken - overlap,
+            tokenEnd: 0,
+          };
+        }
+      }
+    }
+  }
+
+  finalize();
+  return chunks;
+}

--- a/server/search.ts
+++ b/server/search.ts
@@ -12,23 +12,25 @@ export async function ensureVectorIndex() {
 }
 import { embedText } from './openai';
 import { TranscriptSegment } from '@shared/schema';
+import { chunkTranscript } from './chunking';
 
 export async function indexTranscript(
   transcriptId: number,
   segments: TranscriptSegment[]
 ): Promise<void> {
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    const embedding = await embedText(seg.text);
+  const chunks = chunkTranscript(segments);
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const embedding = await embedText(chunk.text);
     await db.insert(transcriptVectors).values({
       transcriptId,
       chunkId: i,
-      speaker: seg.speaker ?? null,
-      text: seg.text,
-      tsStart: seg.start,
-      tsEnd: seg.end,
-      tokenStart: 0,
-      tokenEnd: seg.text.split(/\s+/).length,
+      speaker: chunk.speaker,
+      text: chunk.text,
+      tsStart: chunk.tsStart,
+      tsEnd: chunk.tsEnd,
+      tokenStart: chunk.tokenStart,
+      tokenEnd: chunk.tokenEnd,
       embedding,
     });
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,6 +1,7 @@
 import {
   transcriptions,
   transcriptionRevisions,
+  collabTranscriptRevisions,
   comments,
   type Transcription,
   type InsertTranscription,
@@ -122,6 +123,43 @@ export class DatabaseStorage implements IStorage {
     }
     
     return path.join(audioDir, audioFile);
+  }
+
+  // Comment operations -----------------------------------------------------
+  async createComment(comment: InsertComment): Promise<Comment> {
+    const [row] = await db
+      .insert(comments)
+      .values(comment)
+      .returning();
+    return row;
+  }
+
+  async getComments(transcriptionId: number): Promise<Comment[]> {
+    return db
+      .select()
+      .from(comments)
+      .where(eq(comments.transcriptId, transcriptionId));
+  }
+
+  async updateComment(id: number, updates: Partial<Comment>): Promise<Comment | undefined> {
+    const [row] = await db
+      .update(comments)
+      .set(updates)
+      .where(eq(comments.id, id))
+      .returning();
+    return row || undefined;
+  }
+
+  async deleteComment(id: number): Promise<void> {
+    await db.delete(comments).where(eq(comments.id, id));
+  }
+
+  async saveRevision(transcriptionId: number, snapshot: string, ops: number[]): Promise<void> {
+    await db.insert(collabTranscriptRevisions).values({
+      transcriptId: transcriptionId,
+      snapshot,
+      ops,
+    });
   }
 // DATABASE STORAGE METHODS FOR TRANSCRIPTION HISTORY
 async addRevision(transcriptionId: number, text: string): Promise<void> {


### PR DESCRIPTION
## Summary
- implement database-backed comment and revision snapshot operations
- add transcript chunking utility
- index transcripts using chunked segments

## Testing
- `npm run check` *(fails: Cannot find module declarations)*