### PR TITLE
Implement Yjs revision storage

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,6 +1,7 @@
 import {
   transcriptions,
   transcriptionRevisions,
+  collabTranscriptRevisions,
   comments,
   type Transcription,
   type InsertTranscription,
@@ -31,7 +32,7 @@ export interface IStorage {
   deleteComment(id: number): Promise<void>;
 
   // Collaborative Editing Snapshot (if using Yjs)
-  saveRevision(transcriptionId: number, snapshot: string, ops: number[]): Promise<void>;
+  saveRevision(transcriptionId: number, snapshot: string, ops: number): Promise<void>;
 
   // Transcription Revision History
   addRevision(transcriptionId: number, text: string): Promise<void>;
@@ -122,6 +123,14 @@ export class DatabaseStorage implements IStorage {
     }
     
     return path.join(audioDir, audioFile);
+  }
+
+  async saveRevision(transcriptionId: number, snapshot: string, ops: number): Promise<void> {
+    await db.insert(collabTranscriptRevisions).values({
+      transcriptId: transcriptionId,
+      snapshot,
+      ops,
+    });
   }
 // DATABASE STORAGE METHODS FOR TRANSCRIPTION HISTORY
 async addRevision(transcriptionId: number, text: string): Promise<void> {
@@ -315,7 +324,7 @@ export class MemStorage implements IStorage {
     }
   }
 
-  async saveRevision(transcriptionId: number, _snapshot: string, _ops: number[]): Promise<void> {
+  async saveRevision(transcriptionId: number, _snapshot: string, _ops: number): Promise<void> {
     // no-op in memory
   }
 


### PR DESCRIPTION
## Summary
- store collaborative Yjs snapshots in Postgres via `DatabaseStorage.saveRevision`
- support ops count storage in DB and memory backends

## Testing
- `npm run check` *(fails: cannot find modules, TS errors)*