### PR TITLE
Implement transcript chunker for embedding

### DIFF
--- a/server/chunker.ts
+++ b/server/chunker.ts
@@ -1,0 +1,61 @@
+import { TranscriptSegment } from '@shared/schema';
+
+export interface TranscriptChunk {
+  chunkId: number;
+  text: string;
+  tokenStart: number;
+  tokenEnd: number;
+  tsStart: number;
+  tsEnd: number;
+  speaker?: string | null;
+}
+
+/**
+ * Split transcript segments into roughly `tokensPerChunk`-sized chunks with `overlap` tokens
+ * overlapping between consecutive chunks.
+ */
+export function chunkTranscriptSegments(
+  segments: TranscriptSegment[],
+  tokensPerChunk = 200,
+  overlap = 50
+): TranscriptChunk[] {
+  const tokens: { word: string; start: number; end: number; speaker?: string }[] = [];
+
+  // Flatten segments into individual tokens so we can create windows across segment boundaries
+  for (const seg of segments) {
+    const segTokens = seg.text.trim().split(/\s+/).filter(Boolean);
+    for (const word of segTokens) {
+      tokens.push({ word, start: seg.start, end: seg.end, speaker: seg.speaker });
+    }
+  }
+
+  if (tokens.length === 0) return [];
+
+  const chunks: TranscriptChunk[] = [];
+  const step = Math.max(1, tokensPerChunk - overlap);
+  let chunkId = 0;
+
+  for (let i = 0; i < tokens.length; i += step) {
+    const endIdx = Math.min(i + tokensPerChunk, tokens.length);
+    const chunkTokens = tokens.slice(i, endIdx);
+    if (chunkTokens.length === 0) break;
+
+    const text = chunkTokens.map((t) => t.word).join(' ');
+    const speakers = new Set(chunkTokens.map((t) => t.speaker).filter(Boolean));
+    const speaker = speakers.size === 1 ? chunkTokens[0].speaker ?? null : null;
+
+    chunks.push({
+      chunkId: chunkId++,
+      text,
+      tokenStart: i,
+      tokenEnd: endIdx,
+      tsStart: chunkTokens[0].start,
+      tsEnd: chunkTokens[chunkTokens.length - 1].end,
+      speaker,
+    });
+
+    if (endIdx === tokens.length) break;
+  }
+
+  return chunks;
+}

--- a/server/search.ts
+++ b/server/search.ts
@@ -12,23 +12,25 @@ export async function ensureVectorIndex() {
 }
 import { embedText } from './openai';
 import { TranscriptSegment } from '@shared/schema';
+import { chunkTranscriptSegments } from './chunker';
 
 export async function indexTranscript(
   transcriptId: number,
   segments: TranscriptSegment[]
 ): Promise<void> {
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    const embedding = await embedText(seg.text);
+  const chunks = chunkTranscriptSegments(segments);
+
+  for (const chunk of chunks) {
+    const embedding = await embedText(chunk.text);
     await db.insert(transcriptVectors).values({
       transcriptId,
-      chunkId: i,
-      speaker: seg.speaker ?? null,
-      text: seg.text,
-      tsStart: seg.start,
-      tsEnd: seg.end,
-      tokenStart: 0,
-      tokenEnd: seg.text.split(/\s+/).length,
+      chunkId: chunk.chunkId,
+      speaker: chunk.speaker ?? null,
+      text: chunk.text,
+      tsStart: chunk.tsStart,
+      tsEnd: chunk.tsEnd,
+      tokenStart: chunk.tokenStart,
+      tokenEnd: chunk.tokenEnd,
       embedding,
     });
   }


### PR DESCRIPTION
## Summary
- add `chunkTranscriptSegments` utility for ~200-token windows
- use chunker when indexing transcripts so chunks are embedded individually
- store token offset info in `transcript_vectors`

## Testing
- `npm run check` *(fails: Cannot find module 'drizzle-orm/pg-core', parameter has implicit any, etc.)*