### PR TITLE
Add comments and history tabs

### DIFF
--- a/client/src/components/CommentList.tsx
+++ b/client/src/components/CommentList.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getQueryFn } from '@/lib/queryClient';
+import { Button } from '@/components/ui/button';
+import { formatTimestamp } from '@/lib/utils';
+
+interface Comment {
+  id: number;
+  body: string;
+  timestamp: number | null;
+  speaker?: string | null;
+}
+
+interface CommentListProps {
+  transcriptId: number;
+  onJump?: (time: number) => void;
+}
+
+export default function CommentList({ transcriptId, onJump }: CommentListProps) {
+  const { data: comments = [] } = useQuery<Comment[]>({
+    queryKey: [`/api/transcriptions/${transcriptId}/comments`],
+    queryFn: getQueryFn({ on401: 'throw' }),
+    enabled: !!transcriptId,
+  });
+
+  if (!comments.length) {
+    return <div className="text-sm text-gray-500">No comments</div>;
+  }
+
+  return (
+    <ul className="space-y-3">
+      {comments.map((comment) => (
+        <li key={comment.id} className="flex gap-3 text-sm">
+          {comment.timestamp !== null && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onJump && onJump(comment.timestamp as number)}
+            >
+              {formatTimestamp(comment.timestamp as number)}
+            </Button>
+          )}
+          <div>
+            {comment.speaker && (
+              <div className="text-xs text-gray-500">{comment.speaker}</div>
+            )}
+            <p>{comment.body}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/components/VersionHistory.tsx
+++ b/client/src/components/VersionHistory.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import DiffMatchPatch from 'diff-match-patch';
+import { Button } from '@/components/ui/button';
+import { apiRequest, getQueryFn } from '@/lib/queryClient';
+
+interface RevisionMeta {
+  revisionNo: number;
+  createdAt: string;
+}
+
+interface VersionHistoryProps {
+  transcriptId: number;
+  currentText: string;
+}
+
+export default function VersionHistory({ transcriptId, currentText }: VersionHistoryProps) {
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const { data: revisions = [] } = useQuery<RevisionMeta[]>({
+    queryKey: [`/api/transcriptions/${transcriptId}/revisions`],
+    queryFn: getQueryFn({ on401: 'throw' }),
+    enabled: !!transcriptId,
+  });
+
+  const { data: revisionText } = useQuery({
+    queryKey: [`/api/transcriptions/${transcriptId}/revisions`, selected],
+    queryFn: async () => {
+      const res = await apiRequest('GET', `/api/transcriptions/${transcriptId}/revisions/${selected}`);
+      return res.text();
+    },
+    enabled: selected !== null,
+  });
+
+  const diffHtml = useMemo(() => {
+    if (revisionText && currentText) {
+      const dmp = new DiffMatchPatch();
+      const diff = dmp.diff_main(revisionText, currentText);
+      dmp.diff_cleanupSemantic(diff);
+      return dmp.diff_prettyHtml(diff);
+    }
+    return '';
+  }, [revisionText, currentText]);
+
+  const restoreMutation = useMutation({
+    mutationFn: async () => {
+      if (revisionText == null) return;
+      await apiRequest('PATCH', `/api/transcriptions/${transcriptId}`, { text: revisionText });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/transcriptions/${transcriptId}`] });
+    },
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {revisions.map((rev) => (
+          <Button
+            key={rev.revisionNo}
+            variant={rev.revisionNo === selected ? 'default' : 'outline'}
+            onClick={() => setSelected(rev.revisionNo)}
+          >
+            {rev.revisionNo}
+          </Button>
+        ))}
+      </div>
+      {diffHtml && (
+        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: diffHtml }} />
+      )}
+      {selected !== null && (
+        <Button onClick={() => restoreMutation.mutate()} disabled={restoreMutation.isPending}>
+          {restoreMutation.isPending ? 'Restoring...' : 'Restore'}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/TranscriptionDetail.tsx
+++ b/client/src/pages/TranscriptionDetail.tsx
@@ -4,18 +4,18 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiRequest, getQueryFn } from "@/lib/queryClient";
 import { TranscriptEditor } from '@/components/TranscriptEditor';
 import CollaborativeEditor from '@/components/CollaborativeEditor';
-import NavigableTranscript from '@/components/NavigableTranscript';
 import SpeakerLabels from '@/components/SpeakerLabels';
 import TranscriptView from '@/components/TranscriptView';
 import TranscriptSearch from '@/components/TranscriptSearch';
 import SpeakerSimilarity from '@/components/SpeakerSimilarity';
+import CommentList from '@/components/CommentList';
+import VersionHistory from '@/components/VersionHistory';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2, Trash, Download, FileText } from 'lucide-react';
 import { Transcription, StructuredTranscript } from '@shared/schema';
-import DiffMatchPatch from 'diff-match-patch';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,7 +37,6 @@ export default function TranscriptionDetail() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isGeneratingSummary, setIsGeneratingSummary] = useState(false);
   const [isMergingSpeakers, setIsMergingSpeakers] = useState(false);
-  const [selectedRev, setSelectedRev] = useState<number | null>(null);
   const [searchTime, setSearchTime] = useState<number | null>(null);
   
   const id = params?.id;
@@ -49,33 +48,6 @@ export default function TranscriptionDetail() {
     enabled: !!id,
   });
 
-  const { data: revisions = [] } = useQuery({
-    queryKey: [`/api/transcriptions/${id}/revisions`],
-    queryFn: getQueryFn({ on401: 'throw' }),
-    enabled: !!id,
-  });
-
-  const { data: revisionText } = useQuery({
-    queryKey: [`/api/transcriptions/${id}/revisions`, selectedRev],
-    queryFn: async () => {
-      const response = await apiRequest(
-        'GET',
-        `/api/transcriptions/${id}/revisions/${selectedRev}`
-      );
-      return await response.text();
-    },
-    enabled: !!id && selectedRev !== null,
-  });
-
-  const diffHtml = useMemo(() => {
-    if (revisionText && transcription?.text) {
-      const dmp = new DiffMatchPatch();
-      const diff = dmp.diff_main(revisionText, transcription.text);
-      dmp.diff_cleanupSemantic(diff);
-      return dmp.diff_prettyHtml(diff);
-    }
-    return '';
-  }, [revisionText, transcription?.text]);
 
   // Handle save transcript mutation
   const saveTranscriptMutation = useMutation({
@@ -363,10 +335,11 @@ export default function TranscriptionDetail() {
         )}
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-4 bg-white shadow-sm mb-2">
+          <TabsList className="grid w-full max-w-md grid-cols-5 bg-white shadow-sm mb-2">
             <TabsTrigger value="view" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">View</TabsTrigger>
             <TabsTrigger value="edit" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">Edit</TabsTrigger>
             <TabsTrigger value="speakers" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">Speakers</TabsTrigger>
+            <TabsTrigger value="comments" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">Comments</TabsTrigger>
             <TabsTrigger value="history" className="data-[state=active]:bg-blue-50 data-[state=active]:text-blue-700">History</TabsTrigger>
           </TabsList>
 
@@ -412,21 +385,12 @@ export default function TranscriptionDetail() {
             )}
           </TabsContent>
 
-          <TabsContent value="history" className="mt-4 space-y-4">
-            <div className="flex flex-wrap gap-2">
-              {revisions.map((rev: any) => (
-                <Button
-                  key={rev.revisionNo}
-                  variant={rev.revisionNo === selectedRev ? 'default' : 'outline'}
-                  onClick={() => setSelectedRev(rev.revisionNo)}
-                >
-                  {rev.revisionNo}
-                </Button>
-              ))}
-            </div>
-            {diffHtml && (
-              <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: diffHtml }} />
-            )}
+          <TabsContent value="comments" className="mt-4">
+            <CommentList transcriptId={transcription.id} onJump={(t) => setSearchTime(t)} />
+          </TabsContent>
+
+          <TabsContent value="history" className="mt-4">
+            <VersionHistory transcriptId={transcription.id} currentText={transcription.text || ''} />
           </TabsContent>
         </Tabs>
       </div>


### PR DESCRIPTION
## Summary
- enable comment and version history views in transcription detail page
- show timestamped comments with jump buttons
- show revision list with diff and restore support

## Testing
- `npm run check` *(fails: Cannot find module 'path', etc.)*