### PR TITLE
Implement action-item webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Results contain chunk text, timestamps and a relevance score.
 
 ## Action Item Webhooks
 
-When a comment of type `action-item` is created, the server forwards the item to the URLs defined in `ACTION_ITEM_WEBHOOK_URLS` (comma separated). Use this to integrate with ClickUp or Notion.
+When a comment of type `action-item` is created, the server forwards the item to configured webhook URLs. Define endpoints using `CLICKUP_WEBHOOK_URL`, `NOTION_WEBHOOK_URL`, or a comma separated list in `ACTION_ITEM_WEBHOOK_URLS`. The payload includes the comment text and optional `dueDate`.
 
 ## Tests
 

--- a/server/integrations.ts
+++ b/server/integrations.ts
@@ -1,5 +1,30 @@
-export async function sendActionItemWebhook(data: { transcriptionId: number; body: string }) {
-  const urls = (process.env.ACTION_ITEM_WEBHOOK_URLS || '').split(',').map(u => u.trim()).filter(Boolean);
+export interface ActionItemData {
+  transcriptionId: number;
+  body: string;
+  dueDate?: string;
+}
+
+function getWebhookUrls(): string[] {
+  const urls: string[] = [];
+  if (process.env.CLICKUP_WEBHOOK_URL) {
+    urls.push(process.env.CLICKUP_WEBHOOK_URL);
+  }
+  if (process.env.NOTION_WEBHOOK_URL) {
+    urls.push(process.env.NOTION_WEBHOOK_URL);
+  }
+  if (process.env.ACTION_ITEM_WEBHOOK_URLS) {
+    urls.push(
+      ...process.env.ACTION_ITEM_WEBHOOK_URLS
+        .split(',')
+        .map((u) => u.trim())
+        .filter(Boolean),
+    );
+  }
+  return urls;
+}
+
+export async function sendActionItemWebhook(data: ActionItemData): Promise<void> {
+  const urls = getWebhookUrls();
   for (const url of urls) {
     try {
       await fetch(url, {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1104,14 +1104,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'Transcription not found' });
       }
 
+      const { dueDate, ...commentInput } = req.body;
       const data = insertCommentSchema.parse({
-        ...req.body,
+        ...commentInput,
         transcriptId: id,
       });
       const comment = await storage.createComment(data);
 
       if (data.kind === 'action-item') {
-        await sendActionItemWebhook({ transcriptionId: id, body: data.body });
+        await sendActionItemWebhook({
+          transcriptionId: id,
+          body: data.body,
+          dueDate: typeof dueDate === 'string' ? dueDate : undefined,
+        });
       }
 
       return res.status(201).json(comment);
@@ -1346,11 +1351,21 @@ app.post('/api/transcriptions/:id/comments', async (req: Request, res: Response)
   }
 
   try {
+    const { dueDate, ...commentInput } = req.body;
     const data = insertCommentSchema.parse({
-      ...req.body,
+      ...commentInput,
       transcriptId: id,
     });
     const comment = await storage.createComment(data);
+
+    if (data.kind === 'action-item') {
+      await sendActionItemWebhook({
+        transcriptionId: id,
+        body: data.body,
+        dueDate: typeof dueDate === 'string' ? dueDate : undefined,
+      });
+    }
+
     return res.status(201).json(comment);
   } catch (error) {
     if (error instanceof ZodError) {


### PR DESCRIPTION
## Summary
- trigger ClickUp/Notion webhooks when creating `action-item` comments
- allow configuring webhook URLs through env vars
- include `dueDate` in webhook payload
- document new webhook configuration

## Testing
- `npx tsx tests/runTests.ts` *(fails: EHOSTUNREACH)*