### PR TITLE
Implement LLM tagging job

### DIFF
--- a/server/openai.ts
+++ b/server/openai.ts
@@ -559,6 +559,36 @@ export async function translateTranscript(text: string | null, targetLanguage: s
   }
 }
 
+export async function tagText(text: string): Promise<string[]> {
+  const response = await limiter.schedule(() =>
+    withRetry(() =>
+      openai.chat.completions.create({
+        model: "gpt-4o",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You label transcript excerpts with the tags 'Decision', 'Risk', or 'Date'. Respond as JSON {\"tags\": string[]}. Return an empty array if no tags apply.",
+          },
+          { role: "user", content: text },
+        ],
+        response_format: { type: "json_object" },
+        temperature: 0,
+        max_tokens: 20,
+      })
+    )
+  );
+
+  try {
+    const content = response.choices[0].message.content || "";
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed.tags) ? parsed.tags : [];
+  } catch (err) {
+    console.error("Failed to parse tag response", err);
+    return [];
+  }
+}
+
 /**
  * Transcribe audio with advanced speaker diarization using pyannote.audio
  * This function uses the more accurate pyannote diarization instead of the text-based approach

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,6 +23,7 @@ import {
   autoMergeSpeakers
 } from "./openai";
 import { indexTranscript, searchTranscript } from "./search";
+import { tagTranscriptVectors } from "./tagger";
 import { sendActionItemWebhook } from "./integrations";
 import { transcribeWithAssemblyAI, formatTranscriptText } from "./assemblyai";
 import { transcribeWithHybridApproach } from "./hybrid";
@@ -439,6 +440,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             structuredTranscript: JSON.stringify(result.structuredTranscript)
           });
           await indexTranscript(transcriptionId, result.structuredTranscript.segments);
+          tagTranscriptVectors(transcriptionId).catch(err => console.error('tagging failed', err));
           
         } catch (error) {
           console.error("Error during chunked file transcription:", error);
@@ -670,6 +672,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             structuredTranscript: JSON.stringify(result.structuredTranscript)
           });
           await indexTranscript(transcription.id, result.structuredTranscript.segments);
+          tagTranscriptVectors(transcription.id).catch(err => console.error('tagging failed', err));
         } catch (error) {
           // Handle errors and update the record (Original simpler error handling)
           const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1604,6 +1607,7 @@ app.get('/api/transcriptions/:id/collab-token', async (req: Request, res: Respon
                   structuredTranscript: JSON.stringify(result.structuredTranscript)
                 });
                 await indexTranscript(id, result.structuredTranscript.segments);
+                tagTranscriptVectors(id).catch(err => console.error('tagging failed', err));
               } else {
                 // Use basic transcription for simple cases
                 const result = await transcribeAudio(file.path);

--- a/server/tagger.ts
+++ b/server/tagger.ts
@@ -1,0 +1,26 @@
+import { db } from './db';
+import { transcriptVectors } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import { tagText } from './openai';
+
+export async function tagTranscriptVectors(
+  transcriptId: number,
+  options: { db?: any; tagFn?: (text: string) => Promise<string[]> } = {}
+) {
+  const database = options.db ?? db;
+  const tagFn = options.tagFn ?? tagText;
+
+  const rows = await database
+    .select()
+    .from(transcriptVectors)
+    .where(eq(transcriptVectors.transcriptId, transcriptId));
+
+  for (const row of rows) {
+    const tags = await tagFn(row.text ?? '');
+    await database
+      .update(transcriptVectors)
+      .set({ tags })
+      .where(eq(transcriptVectors.id, row.id));
+  }
+}
+

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -205,6 +205,7 @@ export const transcriptVectors = pgTable("transcript_vectors", {
   tokenStart: integer("token_start"),
   tokenEnd: integer("token_end"),
   embedding: vector("embedding", { dimensions: 1536 }),
+  tags: text("tags").array(),
 });
 
 export const insertVectorSchema = createInsertSchema(transcriptVectors);


### PR DESCRIPTION
## Summary
- extend transcript vector schema with `tags` array
- add OpenAI helper to classify chunk text
- create background tagging job
- run tagging after transcript indexing

## Testing
- `npm run test` *(fails: tsx not found)*