### PR TITLE
Implement tag filter search

### DIFF
--- a/client/src/components/TranscriptSearch.tsx
+++ b/client/src/components/TranscriptSearch.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { apiRequest } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 
 interface SearchResult {
   chunk_id: number;
@@ -20,12 +21,20 @@ export default function TranscriptSearch({ transcriptId, onJump }: TranscriptSea
   const [q, setQ] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+    );
+  };
 
   const handleSearch = async () => {
     if (!q.trim()) return;
     setLoading(true);
     try {
-      const resp = await apiRequest('GET', `/api/search?q=${encodeURIComponent(q)}&transcript_id=${transcriptId}`);
+      const tagParam = selectedTags.length > 0 ? `&tags=${selectedTags.join(',')}` : '';
+      const resp = await apiRequest('GET', `/api/search?q=${encodeURIComponent(q)}&transcript_id=${transcriptId}${tagParam}`);
       const data = await resp.json();
       setResults(data as SearchResult[]);
     } finally {
@@ -35,7 +44,7 @@ export default function TranscriptSearch({ transcriptId, onJump }: TranscriptSea
 
   return (
     <div className="space-y-2">
-      <div className="flex gap-2">
+      <div className="flex gap-2 items-center">
         <input
           type="text"
           value={q}
@@ -46,6 +55,17 @@ export default function TranscriptSearch({ transcriptId, onJump }: TranscriptSea
         <Button onClick={handleSearch} disabled={loading} size="sm">
           Search
         </Button>
+      </div>
+      <div className="flex gap-4 text-sm">
+        {['Decision', 'Risk', 'Date'].map(tag => (
+          <label key={tag} className="flex items-center gap-1">
+            <Checkbox
+              checked={selectedTags.includes(tag)}
+              onCheckedChange={() => toggleTag(tag)}
+            />
+            {tag}
+          </label>
+        ))}
       </div>
       {results.length > 0 && (
         <ul className="border rounded p-2 max-h-60 overflow-y-auto space-y-1 text-sm bg-white">

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -31,7 +31,7 @@ This document lists tasks required to bring the implementation up to the require
    - Implement background job that tags transcript chunks with `Decision`, `Risk`, or `Date` labels using an LLM.
    - Store tags in `transcript_vectors` or a new table referenced by chunk.
 
-7. **Faceted Search Filters**
+7. **Faceted Search Filters** ✅
    - Extend the search API to filter by tags (e.g., only show `Decision` chunks).
    - Update the client search UI to allow toggling these smart filters.
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1785,8 +1785,11 @@ app.get('/api/transcriptions/:id/collab-token', async (req: Request, res: Respon
       const query = z.string().min(1).parse(req.query.q);
       const transcriptId = z.coerce.number().parse(req.query.transcript_id);
       const top = req.query.top ? z.coerce.number().parse(req.query.top) : 10;
+      const tags = typeof req.query.tags === 'string'
+        ? req.query.tags.split(',').map(t => t.trim()).filter(Boolean)
+        : [];
 
-      const results = await searchTranscript(transcriptId, query, top);
+      const results = await searchTranscript(transcriptId, query, top, tags);
       return res.json(results);
     } catch (err) {
       if (err instanceof ZodError) {

--- a/server/search.js
+++ b/server/search.js
@@ -48,6 +48,7 @@ export async function indexTranscript(transcriptId, segments, options = {}) {
       tokenStart: 0,
       tokenEnd: seg.text.split(/\s+/).length,
       embedding,
+      tags: seg.tags ?? null,
     });
   }
 }
@@ -62,18 +63,24 @@ export async function indexTranscript(transcriptId, segments, options = {}) {
 export async function searchTranscript(transcriptId, query, top, options = {}) {
   const database = options.db ?? defaultDb;
   const embed = options.embedFn ?? defaultEmbed;
+  const tags = options.tags ?? [];
   const embedding = await embed(query);
   if (database.execute.length === 1) {
     // custom mock database
-    return (await database.execute({ transcriptId, embedding, top })).rows;
+    return (await database.execute({ transcriptId, embedding, top, tags })).rows;
   }
+  const limit = tags.length > 0 ? top * 10 : top;
   const result = await database.execute(sql`
-    SELECT chunk_id, speaker, ts_start, ts_end, text,
+    SELECT chunk_id, speaker, ts_start, ts_end, text, tags,
       1 - (embedding <#> ${embedding}) AS score
     FROM transcript_vectors
     WHERE transcript_id = ${transcriptId}
     ORDER BY embedding <#> ${embedding}
-    LIMIT ${top}
+    LIMIT ${limit}
   `);
-  return result.rows;
+  let rows = result.rows;
+  if (tags.length > 0) {
+    rows = rows.filter(r => Array.isArray(r.tags) && r.tags.some(t => tags.includes(t))).slice(0, top);
+  }
+  return rows;
 }

--- a/server/search.ts
+++ b/server/search.ts
@@ -19,7 +19,7 @@ import { chunkTranscript } from './chunking';
 
 export async function indexTranscript(
   transcriptId: number,
-  segments: TranscriptSegment[]
+  segments: (TranscriptSegment & { tags?: string[] })[]
 ): Promise<void> {
 const chunks = chunkTranscript(segments);
 
@@ -37,6 +37,7 @@ for (let i = 0; i < chunks.length; i++) {
     tokenStart: chunk.tokenStart,
     tokenEnd: chunk.tokenEnd,
     embedding,
+    tags: (segments[i] as any).tags ?? null,
    });
   }
 }
@@ -44,7 +45,8 @@ for (let i = 0; i < chunks.length; i++) {
 export async function searchTranscript(
   transcriptId: number,
   query: string,
-  top: number
+  top: number,
+  tags: string[] = []
 ): Promise<{
   chunk_id: number;
   speaker: string | null;
@@ -54,13 +56,19 @@ export async function searchTranscript(
   score: number;
 }[]> {
   const embedding = await embedText(query);
+  const limit = tags.length > 0 ? top * 10 : top;
   const result = await db.execute(sql`
-    SELECT chunk_id, speaker, ts_start, ts_end, text,
+    SELECT chunk_id, speaker, ts_start, ts_end, text, tags,
       1 - (embedding <#> ${embedding}) AS score
     FROM transcript_vectors
     WHERE transcript_id = ${transcriptId}
     ORDER BY embedding <#> ${embedding}
-    LIMIT ${top}
+    LIMIT ${limit}
   `);
-  return result.rows as any;
+  let rows = result.rows as any[];
+  if (tags.length > 0) {
+    rows = rows.filter(r => Array.isArray(r.tags) && r.tags.some((t: string) => tags.includes(t)));
+    rows = rows.slice(0, top);
+  }
+  return rows as any;
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -205,6 +205,7 @@ export const transcriptVectors = pgTable("transcript_vectors", {
   tokenStart: integer("token_start"),
   tokenEnd: integer("token_end"),
   embedding: vector("embedding", { dimensions: 1536 }),
+  tags: text("tags").array(),
 });
 
 export const insertVectorSchema = createInsertSchema(transcriptVectors);

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -6,14 +6,16 @@ class MockDB {
   constructor() { this.vectors = []; }
   insert() { return { values: async (v) => { this.vectors.push(v); } }; }
   async execute() {
-    const { transcriptId, embedding, top } = this.lastQuery;
-    const items = this.vectors.filter(v => v.transcriptId === transcriptId);
+    const { transcriptId, embedding, top, tags = [] } = this.lastQuery;
+    const items = this.vectors.filter(v => v.transcriptId === transcriptId &&
+      (tags.length === 0 || (v.tags ?? []).some(t => tags.includes(t))));
     const scored = items.map(v => ({
       chunk_id: v.chunkId,
       speaker: v.speaker,
       ts_start: v.tsStart,
       ts_end: v.tsEnd,
       text: v.text,
+      tags: v.tags,
       score: 1 - Math.abs(v.embedding[0] - embedding[0]),
     })).sort((a,b)=>b.score-a.score).slice(0, top);
     return { rows: scored };
@@ -37,4 +39,16 @@ test('searchTranscript returns best match', async () => {
   const results = await searchTranscript(1, 'hi', 1, { db, embedFn: embed });
   assert.equal(results.length, 1);
   assert.equal(results[0].chunk_id, 0);
+});
+
+test('searchTranscript filters by tags', async () => {
+  const segments = [
+    { start: 0, end: 1, text: 'decision made', tags: ['Decision'] },
+    { start: 1, end: 2, text: 'risky choice', tags: ['Risk'] },
+  ];
+  await indexTranscript(2, segments, { db, embedFn: embed });
+  db.lastQuery = { transcriptId: 2, embedding: [3], top: 2, tags: ['Risk'] };
+  const results = await searchTranscript(2, 'foo', 2, { db, embedFn: embed, tags: ['Risk'] });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].text, 'risky choice');
 });


### PR DESCRIPTION
## Summary
- support array `tags` column on `transcript_vectors`
- allow optional tags when indexing and searching
- add query param in `/api/search` for tags
- add tag filter checkboxes to transcript search UI
- test searchTranscript filtering by tags
- mark faceted search filters task as complete

## Testing
- `node --test tests/*.js`