### PR TITLE
Implement query caching and indexing worker

### DIFF
--- a/server/collab.ts
+++ b/server/collab.ts
@@ -5,6 +5,7 @@ import { setupWSConnection } from 'y-websocket/bin/utils.js';
 import { RedisPersistence } from 'y-redis';
 import * as Y from 'yjs';
 import { storage } from './storage';
+import { scheduleReindex } from './search';
 
 interface DocInfo {
   doc: Y.Doc;
@@ -30,6 +31,7 @@ function trackDoc(name: string, doc: Y.Doc) {
     const id = Number(name.replace(/^transcription-/, ''));
     if (!Number.isNaN(id)) {
       storage.saveRevision(id, snapshot, info.ops).catch(console.error);
+      scheduleReindex(id);
     }
     info.ops = 0;
     info.lastSave = Date.now();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,7 +22,7 @@ import {
   translateTranscript,
   autoMergeSpeakers
 } from "./openai";
-import { indexTranscript, searchTranscript } from "./search";
+import { indexTranscript, searchTranscript, scheduleReindex } from "./search";
 import { tagTranscriptVectors } from "./tagger";
 import { sendActionItemWebhook } from "./integrations";
 import { transcribeWithAssemblyAI, formatTranscriptText } from "./assemblyai";
@@ -1477,6 +1477,7 @@ app.post('/api/transcriptions/:id/save-collab', async (req: Request, res: Respon
     const doc = redis.getYDoc(`transcription-${id}`);
     const snapshot = Buffer.from(Y.encodeStateAsUpdate(doc)).toString('base64');
     await storage.saveRevision(id, snapshot, 0);
+    scheduleReindex(id);
     return res.status(204).end();
   } catch (error) {
     console.error('Error saving collaboration snapshot:', error);

--- a/server/search.js
+++ b/server/search.js
@@ -17,6 +17,39 @@ try {
   ({ embedText: defaultEmbed } = await import('./openai.js'));
 } catch {}
 
+let storage;
+try {
+  ({ storage } = await import('./storage.js'));
+} catch {}
+
+const cache = new Map();
+const CACHE_TTL = 5 * 60 * 1000;
+
+const reindexTimers = new Map();
+
+async function reindexTranscript(id) {
+  if (!storage) return;
+  const t = await storage.getTranscription(id);
+  if (!t || !t.structuredTranscript) return;
+  const data = JSON.parse(t.structuredTranscript);
+  if (!Array.isArray(data.segments)) return;
+  if (defaultDb.execute) {
+    await defaultDb.execute(sql`DELETE FROM transcript_vectors WHERE transcript_id = ${id}`);
+  }
+  await indexTranscript(id, data.segments);
+}
+
+export function scheduleReindex(id, delay = 30000) {
+  if (reindexTimers.has(id)) clearTimeout(reindexTimers.get(id));
+  reindexTimers.set(
+    id,
+    setTimeout(() => {
+      reindexTimers.delete(id);
+      reindexTranscript(id).catch(console.error);
+    }, delay)
+  );
+}
+
 export async function ensureVectorIndex(database = defaultDb) {
   await database.execute(sql`
     CREATE INDEX IF NOT EXISTS transcript_vectors_embedding_hnsw
@@ -61,13 +94,17 @@ export async function indexTranscript(transcriptId, segments, options = {}) {
  * @param {{db?: any, embedFn?: (text:string)=>Promise<number[]>}} [options]
  */
 export async function searchTranscript(transcriptId, query, top, options = {}) {
-  const database = options.db ?? defaultDb;
-  const embed = options.embedFn ?? defaultEmbed;
-  const tags = options.tags ?? [];
+  const { db: database = defaultDb, embedFn: embed = defaultEmbed, tags = [], bypassCache = false } = options;
+  const key = `${transcriptId}:${query}:${tags.sort().join(',')}`;
+  if (!bypassCache && cache.has(key)) {
+    const c = cache.get(key);
+    if (Date.now() - c.ts < CACHE_TTL) return c.result;
+  }
   const embedding = await embed(query);
   if (database.execute.length === 1) {
-    // custom mock database
-    return (await database.execute({ transcriptId, embedding, top, tags })).rows;
+    const res = (await database.execute({ transcriptId, embedding, top, tags })).rows;
+    cache.set(key, { ts: Date.now(), result: res });
+    return res;
   }
   const limit = tags.length > 0 ? top * 10 : top;
   const result = await database.execute(sql`
@@ -82,5 +119,6 @@ export async function searchTranscript(transcriptId, query, top, options = {}) {
   if (tags.length > 0) {
     rows = rows.filter(r => Array.isArray(r.tags) && r.tags.some(t => tags.includes(t))).slice(0, top);
   }
+  cache.set(key, { ts: Date.now(), result: rows });
   return rows;
 }

--- a/server/search.ts
+++ b/server/search.ts
@@ -1,6 +1,7 @@
 import { db } from './db';
-import { transcriptVectors } from '@shared/schema';
-import { sql } from 'drizzle-orm';
+import { transcriptVectors, transcriptions } from '@shared/schema';
+import { eq, sql } from 'drizzle-orm';
+import { storage } from './storage';
 
 export async function ensureVectorIndex() {
   await db.execute(sql`
@@ -16,29 +17,65 @@ import { chunkTranscriptSegments } from './chunker';
 
 import { chunkTranscript } from './chunking';
 
+// ---- simple in-memory cache for search results ----
+interface CacheEntry {
+  ts: number;
+  result: any;
+}
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const cache = new Map<string, CacheEntry>();
 
+export function clearSearchCache() {
+  cache.clear();
+}
+
+// ---- incremental reindex scheduling ----
+const reindexTimers = new Map<number, NodeJS.Timeout>();
+
+async function reindexTranscript(id: number) {
+  const t = await storage.getTranscription(id);
+  if (!t || !t.structuredTranscript) return;
+  const data = JSON.parse(t.structuredTranscript);
+  if (!Array.isArray(data.segments)) return;
+  await db.delete(transcriptVectors).where(eq(transcriptVectors.transcriptId, id));
+  await indexTranscript(id, data.segments);
+}
+
+export function scheduleReindex(id: number, delay = 30000) {
+  if (reindexTimers.has(id)) {
+    clearTimeout(reindexTimers.get(id)!);
+  }
+  reindexTimers.set(
+    id,
+    setTimeout(() => {
+      reindexTimers.delete(id);
+      reindexTranscript(id).catch(console.error);
+    }, delay)
+  );
+}
 export async function indexTranscript(
   transcriptId: number,
-  segments: (TranscriptSegment & { tags?: string[] })[]
+  segments: (TranscriptSegment & { tags?: string[] })[],
+  options: { db?: any; embedFn?: (text: string) => Promise<number[]> } = {}
 ): Promise<void> {
-const chunks = chunkTranscript(segments);
-
-for (let i = 0; i < chunks.length; i++) {
-  const chunk = chunks[i];
-  const embedding = await embedText(chunk.text);
-
-  await db.insert(transcriptVectors).values({
-    transcriptId,
-    chunkId: i,
-    speaker: chunk.speaker,
-    text: chunk.text,
-    tsStart: chunk.tsStart,
-    tsEnd: chunk.tsEnd,
-    tokenStart: chunk.tokenStart,
-    tokenEnd: chunk.tokenEnd,
-    embedding,
-    tags: (segments[i] as any).tags ?? null,
-   });
+  const database = options.db ?? db;
+  const embedFn = options.embedFn ?? embedText;
+  const chunks = chunkTranscript(segments);
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const embedding = await embedFn(chunk.text);
+    await database.insert(transcriptVectors).values({
+      transcriptId,
+      chunkId: i,
+      speaker: chunk.speaker,
+      text: chunk.text,
+      tsStart: chunk.tsStart,
+      tsEnd: chunk.tsEnd,
+      tokenStart: chunk.tokenStart,
+      tokenEnd: chunk.tokenEnd,
+      embedding,
+      tags: (segments[i] as any).tags ?? null,
+    });
   }
 }
 
@@ -46,7 +83,8 @@ export async function searchTranscript(
   transcriptId: number,
   query: string,
   top: number,
-  tags: string[] = []
+  tags: string[] = [],
+  options: { db?: any; embedFn?: (text: string) => Promise<number[]>; bypassCache?: boolean } = {}
 ): Promise<{
   chunk_id: number;
   speaker: string | null;
@@ -55,9 +93,20 @@ export async function searchTranscript(
   text: string | null;
   score: number;
 }[]> {
-  const embedding = await embedText(query);
+  const cacheKey = `${transcriptId}:${query}:${tags.sort().join(',')}`;
+  if (!options.bypassCache) {
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.ts < CACHE_TTL) {
+      return cached.result;
+    }
+  }
+
+  const database = options.db ?? db;
+  const embedFn = options.embedFn ?? embedText;
+
+  const embedding = await embedFn(query);
   const limit = tags.length > 0 ? top * 10 : top;
-  const result = await db.execute(sql`
+  const result = await database.execute(sql`
     SELECT chunk_id, speaker, ts_start, ts_end, text, tags,
       1 - (embedding <#> ${embedding}) AS score
     FROM transcript_vectors
@@ -70,5 +119,7 @@ export async function searchTranscript(
     rows = rows.filter(r => Array.isArray(r.tags) && r.tags.some((t: string) => tags.includes(t)));
     rows = rows.slice(0, top);
   }
+
+  cache.set(cacheKey, { ts: Date.now(), result: rows });
   return rows as any;
 }

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -52,3 +52,21 @@ test('searchTranscript filters by tags', async () => {
   assert.equal(results.length, 1);
   assert.equal(results[0].text, 'risky choice');
 });
+
+test('searchTranscript caches repeated queries', async () => {
+  const localDb = new MockDB();
+  let embedCalls = 0;
+  let execCalls = 0;
+  const embedFn = async (t) => { embedCalls++; return [t.length]; };
+  localDb.execute = async function() { execCalls++; return MockDB.prototype.execute.call(localDb); };
+  const segments = [ { start:0, end:1, text:'cached segment' } ];
+  await indexTranscript(3, segments, { db: localDb, embedFn });
+  embedCalls = 0;
+  localDb.lastQuery = { transcriptId: 3, embedding: [5], top: 1 };
+  await searchTranscript(3, 'cache', 1, { db: localDb, embedFn });
+  localDb.lastQuery = { transcriptId: 3, embedding: [5], top: 1 };
+  await searchTranscript(3, 'cache', 1, { db: localDb, embedFn });
+  assert.equal(embedCalls, 1);
+  assert.equal(execCalls, 1);
+});
+


### PR DESCRIPTION
## Summary
- introduce in-memory cache for search results
- add incremental reindex scheduling after collaborative edits
- update search functions with cache logic
- trigger reindex from collab gateway and manual save endpoint
- test caching behaviour

## Testing
- `node --test tests/search.test.js`