### PR TITLE
Improve collab token handling

### DIFF
--- a/server/collab.ts
+++ b/server/collab.ts
@@ -69,7 +69,18 @@ export function startCollabGateway(server: Server) {
       url.searchParams.get('token') ||
       (req.headers['sec-websocket-protocol']?.split(',')[0] ?? '');
     try {
-      verify(token, process.env.JWT_SECRET || 'secret');
+      const payload = verify(
+        token,
+        process.env.COLLAB_TOKEN_SECRET || process.env.JWT_SECRET || 'secret'
+      ) as { transcriptionId?: number; scopes?: string[] };
+      const idMatch = url.pathname.match(/transcription-(\d+)/);
+      const docId = idMatch ? Number(idMatch[1]) : NaN;
+      if (!payload.transcriptionId || payload.transcriptionId !== docId) {
+        throw new Error('Invalid transcriptionId');
+      }
+      (req as any).collabScopes = Array.isArray(payload.scopes)
+        ? payload.scopes
+        : [];
     } catch (err) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
       socket.destroy();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -154,8 +154,7 @@ export class DatabaseStorage implements IStorage {
     await db.delete(comments).where(eq(comments.id, id));
   }
 
-  async saveRevision(transcriptionId: number, snapshot: string, ops: number[]): Promise<void> {
-
+  async saveRevision(transcriptionId: number, snapshot: string, ops: number): Promise<void> {
     await db.insert(collabTranscriptRevisions).values({
       transcriptId: transcriptionId,
       snapshot,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -168,7 +168,7 @@ export const collabTranscriptRevisions = pgTable("collab_transcript_revisions", 
     .references(() => transcriptions.id)
     .notNull(),
   snapshot: text("snapshot").notNull(),
-  ops: jsonb("ops").notNull().default([]),
+  ops: integer("ops").notNull().default(0),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 


### PR DESCRIPTION
## Summary
- verify payload claims on WebSocket upgrade
- store operation counts as integers for collab revisions
- fix storage interface to match

## Testing
- `npx tsx tests/runTests.ts` *(fails: tsx not found)*