### PR TITLE
Implement comment due date parsing

### DIFF
--- a/server/openai.ts
+++ b/server/openai.ts
@@ -589,6 +589,45 @@ export async function tagText(text: string): Promise<string[]> {
   }
 }
 
+export async function parseDueDate(text: string): Promise<string | null> {
+  const direct = new Date(text);
+  if (!isNaN(direct.getTime())) {
+    return direct.toISOString();
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return null;
+  }
+
+  const response = await limiter.schedule(() =>
+    withRetry(() =>
+      openai.chat.completions.create({
+        model: "gpt-4o",
+        messages: [
+          {
+            role: "system",
+            content:
+              "Convert natural language due dates into an ISO 8601 timestamp in UTC. Respond as JSON {\"date\": string|null}.",
+          },
+          { role: "user", content: text },
+        ],
+        response_format: { type: "json_object" },
+        temperature: 0,
+        max_tokens: 20,
+      })
+    )
+  );
+
+  try {
+    const content = response.choices[0].message.content || "";
+    const parsed = JSON.parse(content);
+    return typeof parsed.date === "string" ? parsed.date : null;
+  } catch (err) {
+    console.error("Failed to parse due date", err);
+    return null;
+  }
+}
+
 /**
  * Transcribe audio with advanced speaker diarization using pyannote.audio
  * This function uses the more accurate pyannote diarization instead of the text-based approach

--- a/server/routers/comments.ts
+++ b/server/routers/comments.ts
@@ -6,8 +6,21 @@ import { insertCommentSchema } from '@/shared/schema';
 import { sendActionItemWebhook } from '../integrations';
 import { redis } from '../collab';
 import { insertCommentAnchor } from '../yjsHelpers';
+import { parseDueDate } from '../openai';
 
 const router = Router();
+
+async function normalizeDueDate(input: any): Promise<{ date?: Date; iso?: string }> {
+  if (!input) return {};
+  const d = new Date(input);
+  if (!isNaN(d.getTime())) return { date: d, iso: d.toISOString() };
+  const iso = await parseDueDate(String(input));
+  if (iso) {
+    const parsed = new Date(iso);
+    if (!isNaN(parsed.getTime())) return { date: parsed, iso };
+  }
+  return {};
+}
 
 router.get('/api/transcriptions/:id/comments', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id);
@@ -37,10 +50,11 @@ router.post('/api/transcriptions/:id/comments', async (req: Request, res: Respon
 
   try {
     const { dueDate, ...commentInput } = req.body;
+    const parsed = await normalizeDueDate(dueDate);
     const data = insertCommentSchema.parse({
       ...commentInput,
       transcriptId: id,
-      dueDate: req.body.dueDate ? new Date(req.body.dueDate) : undefined,
+      dueDate: parsed.date,
     });
     const comment = await storage.createComment(data);
 
@@ -55,7 +69,7 @@ router.post('/api/transcriptions/:id/comments', async (req: Request, res: Respon
       await sendActionItemWebhook({
         transcriptionId: id,
         body: data.body,
-        dueDate: typeof dueDate === 'string' ? dueDate : undefined,
+        dueDate: parsed.iso,
       });
     }
 
@@ -81,6 +95,7 @@ router.patch('/api/transcriptions/:id/comments/:commentId', async (req: Request,
     return res.status(404).json({ message: 'Transcription not found' });
   }
 
+  const parsed = await normalizeDueDate(req.body.dueDate);
   const updates = {
     yjsPos: req.body.yjsPos,
     body: req.body.body,
@@ -88,7 +103,7 @@ router.patch('/api/transcriptions/:id/comments/:commentId', async (req: Request,
     status: req.body.status,
     assignee: req.body.assignee,
     createdBy: req.body.createdBy,
-    dueDate: req.body.dueDate ? new Date(req.body.dueDate) : undefined,
+    dueDate: parsed.date,
     metadata: req.body.metadata,
     absolutePosition: req.body.absolutePosition,
   } as any;

--- a/server/routes/comments.ts
+++ b/server/routes/comments.ts
@@ -7,10 +7,23 @@ import { ZodError } from 'zod';
 import { fromZodError } from 'zod-validation-error';
 import { redis } from '../collab';
 import * as Y from 'yjs';
+import { parseDueDate } from '../openai';
 
 import { insertCommentAnchor } from '../yjsHelpers';
 
 export const commentsRouter = Router();
+
+async function normalizeDueDate(input: any): Promise<{ date?: Date; iso?: string }> {
+  if (!input) return {};
+  const d = new Date(input);
+  if (!isNaN(d.getTime())) return { date: d, iso: d.toISOString() };
+  const iso = await parseDueDate(String(input));
+  if (iso) {
+    const parsed = new Date(iso);
+    if (!isNaN(parsed.getTime())) return { date: parsed, iso };
+  }
+  return {};
+}
 
 
 commentsRouter.get('/api/transcriptions/:id/comments', async (req: Request, res: Response) => {
@@ -29,12 +42,12 @@ commentsRouter.post('/api/transcriptions/:id/comments', async (req: Request, res
   if (!transcription) return res.status(404).json({ message: 'Transcription not found' });
 
   try {
-
     const { dueDate, ...commentInput } = req.body;
+    const parsed = await normalizeDueDate(dueDate);
     const data = insertCommentSchema.parse({
       ...commentInput,
       transcriptId: id,
-      dueDate: req.body.dueDate ? new Date(req.body.dueDate) : undefined,
+      dueDate: parsed.date,
     });
     const comment = await storage.createComment(data);
 
@@ -42,7 +55,7 @@ commentsRouter.post('/api/transcriptions/:id/comments', async (req: Request, res
       await sendActionItemWebhook({
         transcriptionId: id,
         body: data.body,
-        dueDate: typeof dueDate === 'string' ? dueDate : undefined,
+        dueDate: parsed.iso,
       });
     }
 
@@ -81,7 +94,7 @@ commentsRouter.patch('/api/transcriptions/:id/comments/:commentId', async (req: 
     status: req.body.status,
     assignee: req.body.assignee,
     createdBy: req.body.createdBy,
-    dueDate: req.body.dueDate ? new Date(req.body.dueDate) : undefined,
+    dueDate: (await normalizeDueDate(req.body.dueDate)).date,
     metadata: req.body.metadata,
     absolutePosition: req.body.absolutePosition,
 

--- a/tests/dueDate.test.js
+++ b/tests/dueDate.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDueDate } from '../server/openai.js';
+
+test('parseDueDate returns ISO for valid date', async () => {
+  const iso = await parseDueDate('2025-05-01');
+  assert.ok(typeof iso === 'string' && iso.startsWith('2025-05-01'));
+});
+
+test('parseDueDate returns null for invalid date', async () => {
+  const iso = await parseDueDate('not a date');
+  assert.equal(iso, null);
+});


### PR DESCRIPTION
## Summary
- enhance comment APIs to parse natural language due dates
- add `parseDueDate` helper using OpenAI
- wire comment POST/PATCH routes to use parsed due dates
- add unit test for `parseDueDate`

## Testing
- `npm test` *(fails: tsx not found)*