### PR TITLE
Add comment UI and due date parsing

### DIFF
--- a/client/src/components/CommentForm.tsx
+++ b/client/src/components/CommentForm.tsx
@@ -9,12 +9,6 @@ interface CommentFormProps {
   transcriptId: number;
 }
 
-// Simple placeholder for natural language date parsing
-function parseNaturalLanguageDate(text: string): string | null {
-  const date = new Date(text);
-  return isNaN(date.getTime()) ? null : date.toISOString();
-}
-
 export default function CommentForm({ transcriptId }: CommentFormProps) {
   const [body, setBody] = useState('');
   const [assignee, setAssignee] = useState('');
@@ -30,8 +24,7 @@ export default function CommentForm({ transcriptId }: CommentFormProps) {
         kind: 'comment',
         status: 'open',
         assignee: assignee || null,
-        // dueDate is not yet persisted on the server
-        dueDate: parseNaturalLanguageDate(dueText),
+        dueDate: dueText || null,
       });
     },
     onSuccess: () => {

--- a/client/src/components/CommentList.tsx
+++ b/client/src/components/CommentList.tsx
@@ -6,11 +6,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { formatTimestamp } from '@/lib/utils';
 
-function parseNaturalLanguageDate(text: string): string | null {
-  const date = new Date(text);
-  return isNaN(date.getTime()) ? null : date.toISOString();
-}
-
 interface Comment {
   id: number;
   body: string;
@@ -54,7 +49,7 @@ export default function CommentList({ transcriptId, onJump }: CommentListProps) 
     await apiRequest('PATCH', `/api/transcriptions/${transcriptId}/comments/${commentId}`, {
       body,
       assignee: assignee || null,
-      dueDate: parseNaturalLanguageDate(dueText),
+      dueDate: dueText || null,
     });
   };
 

--- a/client/src/components/TranscriptView.tsx
+++ b/client/src/components/TranscriptView.tsx
@@ -5,6 +5,8 @@ import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { CheckCircle2, Calendar, Users, FileText, Mic } from "lucide-react";
 import SpeakerLabels from "./SpeakerLabels";
+import CommentForm from "./CommentForm";
+import CommentList from "./CommentList";
 import { formatTimestamp, getSpeakerColorClass } from "@/lib/utils";
 
 interface TranscriptViewProps {
@@ -199,6 +201,15 @@ export default function TranscriptView({
             </div>
           )}
         </ScrollArea>
+      </div>
+
+      <Separator className="my-4" />
+      <div>
+        <h3 className="font-semibold mb-2">Comments</h3>
+        <div className="mb-4">
+          <CommentForm transcriptId={transcription.id} />
+        </div>
+        <CommentList transcriptId={transcription.id} />
       </div>
     </div>
   );

--- a/server/openai.ts
+++ b/server/openai.ts
@@ -38,6 +38,47 @@ async function withRetry<T>(
   }
 }
 
+export async function parseDateWithLLM(text: string): Promise<string | null> {
+  const input = text.trim();
+  if (!input) return null;
+
+  // Fallback to basic parsing if no API key provided
+  if (!process.env.OPENAI_API_KEY) {
+    const d = new Date(input);
+    return isNaN(d.getTime()) ? null : d.toISOString();
+  }
+
+  try {
+    const resp = await limiter.schedule(() =>
+      withRetry(() =>
+        openai.chat.completions.create({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Convert the user provided date to ISO 8601 format (YYYY-MM-DD). Return only the date.',
+            },
+            { role: 'user', content: input },
+          ],
+          temperature: 0,
+        })
+      )
+    );
+
+    const out = resp.choices?.[0]?.message?.content?.trim() ?? '';
+    const d = new Date(out);
+    if (isNaN(d.getTime())) {
+      const fallback = new Date(input);
+      return isNaN(fallback.getTime()) ? null : fallback.toISOString();
+    }
+    return d.toISOString();
+  } catch {
+    const d = new Date(input);
+    return isNaN(d.getTime()) ? null : d.toISOString();
+  }
+}
+
 export async function embedText(text: string): Promise<number[]> {
   const resp = await limiter.schedule(() =>
     withRetry(() =>

--- a/server/routes/comments.ts
+++ b/server/routes/comments.ts
@@ -3,6 +3,7 @@ import { Router, Request, Response } from 'express';
 import { insertCommentSchema } from '@shared/schema';
 import { storage } from '../storage';
 import { sendActionItemWebhook } from '../integrations';
+import { parseDateWithLLM } from '../openai';
 import { ZodError } from 'zod';
 import { fromZodError } from 'zod-validation-error';
 import { redis } from '../collab';
@@ -31,10 +32,14 @@ commentsRouter.post('/api/transcriptions/:id/comments', async (req: Request, res
   try {
 
     const { dueDate, ...commentInput } = req.body;
+    let parsedDate: string | null = null;
+    if (typeof dueDate === 'string') {
+      parsedDate = await parseDateWithLLM(dueDate);
+    }
     const data = insertCommentSchema.parse({
       ...commentInput,
       transcriptId: id,
-      dueDate: req.body.dueDate ? new Date(req.body.dueDate) : undefined,
+      dueDate: parsedDate ? new Date(parsedDate) : undefined,
     });
     const comment = await storage.createComment(data);
 
@@ -73,18 +78,21 @@ commentsRouter.patch('/api/transcriptions/:id/comments/:commentId', async (req: 
   const transcription = await storage.getTranscription(id);
   if (!transcription) return res.status(404).json({ message: 'Transcription not found' });
 
-  const updates = {
+  let parsedDate: string | null = null;
+  if (typeof req.body.dueDate === 'string') {
+    parsedDate = await parseDateWithLLM(req.body.dueDate);
+  }
 
+  const updates = {
     yjsPos: req.body.yjsPos,
     body: req.body.body,
     kind: req.body.kind,
     status: req.body.status,
     assignee: req.body.assignee,
     createdBy: req.body.createdBy,
-    dueDate: req.body.dueDate ? new Date(req.body.dueDate) : undefined,
+    dueDate: parsedDate ? new Date(parsedDate) : undefined,
     metadata: req.body.metadata,
     absolutePosition: req.body.absolutePosition,
-
   } as any;
 
   const updated = await storage.updateComment(commentId, updates);


### PR DESCRIPTION
## Summary
- integrate comment form and list into `TranscriptView`
- support due-date parsing with OpenAI
- parse due date on create/update comment
- simplify client-side comment forms

## Testing
- `npx --no-install tsx tests/runTests.ts` *(fails: request to https://registry.npmjs.org/tsx failed)*