### PR TITLE
Implement FFmpeg-based audio chunking

### DIFF
--- a/server/audioChunker.ts
+++ b/server/audioChunker.ts
@@ -1,0 +1,53 @@
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const execFilePromise = promisify(execFile);
+
+const DEFAULT_CHUNK_SIZE = 24 * 1024 * 1024; // 24MB to stay under 25MB API limit
+
+export async function getAudioDuration(filePath: string): Promise<number> {
+  const { stdout } = await execFilePromise('ffprobe', [
+    '-v',
+    'error',
+    '-show_entries',
+    'format=duration',
+    '-of',
+    'default=noprint_wrappers=1:nokey=1',
+    filePath,
+  ]);
+  return parseFloat(stdout.trim());
+}
+
+export async function splitAudio(
+  filePath: string,
+  chunkSize = DEFAULT_CHUNK_SIZE,
+): Promise<string[]> {
+  const { size } = fs.statSync(filePath);
+  const duration = await getAudioDuration(filePath);
+  const bytesPerSecond = size / duration;
+  const segmentTime = Math.max(1, Math.floor(chunkSize / bytesPerSecond));
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'audio-chunk-'));
+  const outPattern = path.join(dir, `part-%03d${path.extname(filePath)}`);
+
+  await execFilePromise('ffmpeg', [
+    '-i',
+    filePath,
+    '-f',
+    'segment',
+    '-segment_time',
+    segmentTime.toString(),
+    '-c',
+    'copy',
+    outPattern,
+  ]);
+
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.startsWith('part-'))
+    .map((f) => path.join(dir, f))
+    .sort();
+}

--- a/server/openai.ts
+++ b/server/openai.ts
@@ -5,6 +5,7 @@ import os from "os";
 import Bottleneck from "bottleneck";
 import { TranscriptSegment, StructuredTranscript } from "@shared/schema";
 import { diarizeAudio } from "./diarization";
+import { splitAudio } from "./audioChunker";
 
 interface WhisperSegment {
   start: number;
@@ -30,17 +31,7 @@ const OPENAI_LIMIT_BYTES = 25 * 1024 * 1024;
 const CHUNK_SIZE = 24 * 1024 * 1024;
 
 async function splitFile(filePath: string, chunkSize = CHUNK_SIZE): Promise<string[]> {
-  const chunkPaths: string[] = [];
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "whisper-chunk-"));
-  const stream = fs.createReadStream(filePath, { highWaterMark: chunkSize });
-  let idx = 0;
-  for await (const chunk of stream) {
-    const part = path.join(dir, `part-${idx}${path.extname(filePath)}`);
-    fs.writeFileSync(part, chunk as Buffer);
-    chunkPaths.push(part);
-    idx++;
-  }
-  return chunkPaths;
+  return splitAudio(filePath, chunkSize);
 }
 
 async function transcribeChunk(


### PR DESCRIPTION
## Summary
- add `audioChunker.ts` to split audio files using ffmpeg
- use new chunking logic in OpenAI transcription path

## Testing
- `node --test tests/*.test.js`