### PR TITLE
Implement transcript chunk merging

### DIFF
--- a/server/transcriptMerger.js
+++ b/server/transcriptMerger.js
@@ -1,0 +1,46 @@
+export function mergeChunkTranscripts(chunks) {
+  const mergedSegments = [];
+  const texts = [];
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    texts.push(chunk.text);
+    const segs = (chunk.structuredTranscript && chunk.structuredTranscript.segments) || [];
+    for (const seg of segs) {
+      mergedSegments.push({
+        ...seg,
+        start: seg.start + offset,
+        end: seg.end + offset,
+      });
+    }
+    offset += chunk.duration;
+  }
+
+  const normalized = mergedSegments.reduce((acc, curr) => {
+    if (acc.length === 0) return [curr];
+    const last = acc[acc.length - 1];
+    if (last.speaker === curr.speaker && curr.start <= last.end + 0.5) {
+      last.end = Math.max(last.end, curr.end);
+      last.text = `${last.text} ${curr.text}`.trim();
+      return acc;
+    }
+    acc.push({ ...curr });
+    return acc;
+  }, []);
+
+  const speakers = new Set();
+  normalized.forEach((s) => {
+    if (s.speaker) speakers.add(s.speaker);
+  });
+
+  return {
+    text: texts.join(' '),
+    structuredTranscript: {
+      segments: normalized,
+      metadata: {
+        speakerCount: speakers.size || undefined,
+        duration: offset,
+      },
+    },
+  };
+}

--- a/server/transcriptMerger.ts
+++ b/server/transcriptMerger.ts
@@ -1,0 +1,60 @@
+import { StructuredTranscript, TranscriptSegment } from "@shared/schema";
+
+export interface ChunkResult {
+  text: string;
+  structuredTranscript: StructuredTranscript;
+  duration: number;
+}
+
+export function mergeChunkTranscripts(chunks: ChunkResult[]): {
+  text: string;
+  structuredTranscript: StructuredTranscript;
+} {
+  const mergedSegments: TranscriptSegment[] = [];
+  const texts: string[] = [];
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    texts.push(chunk.text);
+    const segs = chunk.structuredTranscript?.segments || [];
+    for (const seg of segs) {
+      mergedSegments.push({
+        ...seg,
+        start: seg.start + offset,
+        end: seg.end + offset,
+      });
+    }
+    offset += chunk.duration;
+  }
+
+  const normalized: TranscriptSegment[] = mergedSegments.reduce(
+    (acc: TranscriptSegment[], curr) => {
+      if (acc.length === 0) return [curr];
+      const last = acc[acc.length - 1];
+      if (last.speaker === curr.speaker && curr.start <= last.end + 0.5) {
+        last.end = Math.max(last.end, curr.end);
+        last.text = `${last.text} ${curr.text}`.trim();
+        return acc;
+      }
+      acc.push({ ...curr });
+      return acc;
+    },
+    []
+  );
+
+  const speakers = new Set<string>();
+  normalized.forEach((s) => {
+    if (s.speaker) speakers.add(s.speaker);
+  });
+
+  return {
+    text: texts.join(" "),
+    structuredTranscript: {
+      segments: normalized,
+      metadata: {
+        speakerCount: speakers.size || undefined,
+        duration: offset,
+      },
+    },
+  };
+}

--- a/tests/mergeChunks.test.js
+++ b/tests/mergeChunks.test.js
@@ -1,0 +1,25 @@
+import { strict as assert } from 'assert';
+import { mergeChunkTranscripts } from '../server/transcriptMerger.js';
+
+const chunk1 = {
+  text: 'hello world',
+  structuredTranscript: {
+    segments: [{ start: 0, end: 1, text: 'hello', speaker: 'A' }],
+    metadata: { speakerCount: 1, duration: 1 }
+  },
+  duration: 1
+};
+
+const chunk2 = {
+  text: 'foo bar',
+  structuredTranscript: {
+    segments: [{ start: 0, end: 1, text: 'bar', speaker: 'B' }],
+    metadata: { speakerCount: 1, duration: 1 }
+  },
+  duration: 1
+};
+
+const merged = mergeChunkTranscripts([chunk1, chunk2]);
+assert.equal(merged.structuredTranscript.segments.length, 2);
+assert.equal(merged.structuredTranscript.segments[1].start, 1);
+console.log('merge chunks tests passed');


### PR DESCRIPTION
## Summary
- add `mergeChunkTranscripts` helper to combine chunk results
- include compiled JS version for tests
- test merging logic

## Testing
- `node --test tests/mergeChunks.test.js`
- `for f in tests/*.js; do node --test $f; done`